### PR TITLE
添加uglifyjs压缩js任务

### DIFF
--- a/gulp/task/uglifyjs.js
+++ b/gulp/task/uglifyjs.js
@@ -1,0 +1,28 @@
+/**
+ * Created by hkongm on 15/4/20.
+ */
+
+var config = require('config').gulp;
+var gulp = require('gulp');
+var uglify = require('gulp-uglify');
+
+function uglifyjs() {
+  return gulp.src([
+    config.src.js + '/**/*.js'
+  ])
+  .pipe(uglify({
+      output: {
+        ascii_only:true
+      },
+      compress: {
+        drop_console:true
+      }
+    }))
+  .pipe(gulp.dest(config.dist.js))
+}
+
+gulp.task('uglifyjs', uglifyjs);
+
+module.exports = uglifyjs;
+
+

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "gulp-minify-css": "^0.4.5",
     "gulp-sourcemaps": "^1.3.0",
     "gulp-symlink": "^2.1.0",
+    "gulp-uglify": "^1.2.0",
     "jshint-stylish": "^1.0.0",
     "require-dir": "^0.1.0",
     "vinyl-transform": "^1.0.0"


### PR DESCRIPTION
选项：中文压unicode、删除console调试语句

自测通过，执行`gulp uglifyjs`，在dist/scripts下生成`base.min.js`文件
